### PR TITLE
Fixed missing order invoice number bug in CIM transaction.create_transaction

### DIFF
--- a/lib/authorize_net/addresses/address.rb
+++ b/lib/authorize_net/addresses/address.rb
@@ -5,14 +5,14 @@ module AuthorizeNet
     
     include AuthorizeNet::Model
     
-    attr_accessor :first_name, :last_name, :company, :street_address, :city, :state, :zip, :country, :phone, :fax, :customer_address_id
+    attr_accessor :first_name, :last_name, :company, :address, :city, :state, :zip, :country, :phone, :fax, :customer_address_id
     
     def to_hash
       hash = {
         :first_name => @first_name,
         :last_name => @last_name,
         :company => @company,
-        :address => @street_address,
+        :address => @address,
         :city => @city,
         :state => @state,
         :zip => @zip,

--- a/lib/authorize_net/addresses/shipping_address.rb
+++ b/lib/authorize_net/addresses/shipping_address.rb
@@ -10,7 +10,7 @@ module AuthorizeNet
         :ship_to_first_name => @first_name,
         :ship_to_last_name => @last_name,
         :ship_to_company => @company,
-        :ship_to_address => @street_address,
+        :ship_to_address => @address,
         :ship_to_city => @city,
         :ship_to_state => @state,
         :ship_to_zip => @zip,

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -372,7 +372,7 @@ module AuthorizeNet
         {:bankRoutingNumberMasked => :bank_aba_code_masked},
         {:bankAccountNumberMasked => :bank_acct_num_masked},
         {:order => [
-          {:invoiceNumber => :invoice_number},
+          {:invoiceNumber => :invoice_num},
           {:description => :description},
           {:purchaseOrderNumber => :po_num}
         ]},

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -209,7 +209,7 @@ module AuthorizeNet
           {:firstName => :first_name},
           {:lastName => :last_name},
           {:company => :company},
-          {:address => :street_address},
+          {:address => :address},
           {:city => :city},
           {:state => :state},
           {:zip => :zip},

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -209,7 +209,7 @@ module AuthorizeNet
           {:firstName => :first_name},
           {:lastName => :last_name},
           {:company => :company},
-          {:address => :address},
+          {:address => :street_address},
           {:city => :city},
           {:state => :state},
           {:zip => :zip},


### PR DESCRIPTION
Fixed bug when passing order object which contains an invoice number, the invoice number was not being passed along in the transaction to authorize.net.

#sample code
<blockquote>
order = AuthorizeNet::Order.new(:invoice_num => invoice.id, :description => invoice.description)

transaction = AuthorizeNet::CIM::Transaction.new(ENV['AUTHNET_LOGIN'], ENV['AUTHNET_API_KEY'], :gateway => :sandbox)

response = transaction.create_transaction_auth_capture(invoice.balance_due, customer_profile_id, payment_profile_id, order)

if response.success? && response.direct_response.success?
    puts response.direct_response.fields[:invoice_number]
end

</blockquote>
